### PR TITLE
feat: update homepage to reflect current LLM/Multi-Agent research focus

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -23,7 +23,7 @@ import siteConfig from '../data/site-config';
                 </span>
                 <span class="flex items-center gap-2">
                     <svg class="w-3.5 h-3.5 opacity-60" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"/></svg>
-                    AI × Games × PCG
+                    {siteConfig.tagline}
                 </span>
             </div>
         </header>

--- a/src/data/site-config.ts
+++ b/src/data/site-config.ts
@@ -28,6 +28,7 @@ export type SiteConfig = {
     logo?: Image;
     title: string;
     subtitle?: string;
+    tagline?: string;
     description: string;
     image?: Image;
     headerNavLinks?: Link[];
@@ -42,6 +43,7 @@ export type SiteConfig = {
 const siteConfig: SiteConfig = {
     title: 'devcomfort',
     subtitle: 'devcomfort의 기술 블로그 & 포트폴리오',
+    tagline: 'LLM × Multi-Agent System',
     description: 'devcomfort의 기술 블로그 & 포트폴리오',
     headerNavLinks: [
         { text: 'Home', href: '/' },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -131,7 +131,7 @@ const featuredResearch = research.filter(({ data }) => data.isFeatured);
                     Keywords
                 </h3>
                 <div class="flex flex-wrap gap-2">
-                    {['data-preprocessing', 'data-collection', 'research', 'reinforcement-learning', 'procedural-content-generation', 'embedding', 'machine-learning', 'python', 'typescript'].map((tag) => (
+                    {['data-preprocessing', 'data-collection', 'research', 'python', 'typescript', 'agentic-system', 'embedding', 'llm', 'machine-learning', 'reinforcement-learning'].map((tag) => (
                         <a class="font-mono text-xs text-text-secondary bg-bg-muted border border-border-main px-3 py-0.5 rounded-sm hover:bg-accent/8 hover:border-accent hover:text-accent no-underline transition-colors" href={`/tags/${tag}/`}>
                             {tag}
                         </a>


### PR DESCRIPTION
Update homepage header tagline and sidebar Keywords to match current LLM/Multi-Agent research focus.

Changes:
- site-config.ts: add tagline field (LLM x Multi-Agent System)
- Header.astro: replace hardcoded tagline with siteConfig.tagline
- index.astro: remove procedural-content-generation, add agentic-system and llm to Keywords sidebar

Build: 50 pages, 0 errors